### PR TITLE
fix removing multiple :global selectors in a single rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,14 +8,15 @@ module.exports = postcss.plugin(pluginName, () => (root) => {
         // :global as nested selector
         const globalReg = /:global(\s+)/;
         // :global(.selector) as nested selector
-        const globalWithSelectorReg = /:global\(((?:\w|\.|:|#)+)\)/;
+        const globalWithSelectorReg = /:global\(((?:\w|\.|:|#)+)\)/g;
         if (rule.selector === ':global') {
             rule.parent.append(...rule.nodes);
             rule.remove();
         } else if (rule.selector.match(globalReg)) {
             rule.selector = rule.selector.replace(globalReg, '');
         } else if (rule.selector.match(globalWithSelectorReg)) {
-            rule.selector = rule.selector.replace(globalWithSelectorReg, '$1');
+            rule.selector = rule.selector
+                .replaceAll(globalWithSelectorReg, '$1');
         }
     });
     // :global in AtRules

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = postcss.plugin(pluginName, () => (root) => {
         // :global as nested selector
         const globalReg = /:global(\s+)/;
         // :global(.selector) as nested selector
-        const globalWithSelectorReg = /:global\(((?:\w|\.|:|#)+)\)/g;
+        const globalWithSelectorReg = /:global\(((?:\w|-|\.|:|#)+)\)/g;
         if (rule.selector === ':global') {
             rule.parent.append(...rule.nodes);
             rule.remove();
@@ -23,7 +23,7 @@ module.exports = postcss.plugin(pluginName, () => (root) => {
     root.walkAtRules(atRule => {
         const name = atRule.name;
         const params = atRule.params;
-        const globalReg = /:global\((\w+)\)/;
+        const globalReg = /:global\(([\w-]+)\)/;
         if (name === 'keyframes' && params.match(globalReg)) {
             atRule.params = params.replace(globalReg, '$1');
         }

--- a/index.test.js
+++ b/index.test.js
@@ -36,6 +36,22 @@ it('remove :global - as part of selector with multiple spaces', () => {
 });
 
 // eslint-disable-next-line max-len
+it('remove :global - as part of selector with selector with underscores included', () => {
+    return run(
+        '.root :global(.foo_bar__foo) .text { margin: 0 6px; }',
+        '.root .foo_bar__foo .text { margin: 0 6px; }',
+        { });
+});
+
+// eslint-disable-next-line max-len
+it('remove :global - as part of selector with selector with dashes included', () => {
+    return run(
+        '.root :global(.foo-bar--foo) .text { margin: 0 6px; }',
+        '.root .foo-bar--foo .text { margin: 0 6px; }',
+        { });
+});
+
+// eslint-disable-next-line max-len
 it('remove multiple :global - as part of selector with selector included', () => {
     return run(
         '.root :global(.foo) :global(.bar) .text { margin: 0 6px; }',
@@ -43,6 +59,23 @@ it('remove multiple :global - as part of selector with selector included', () =>
         { });
 });
 
+
 it('remove :global - as part of @keyframe params', () => {
     return run('@keyframes :global(zoomIn) { }', '@keyframes zoomIn { }', { });
+});
+
+it('remove :global - as part of @keyframe params with an underscore', () => {
+    return run(
+        '@keyframes :global(zoom_in) { }',
+        '@keyframes zoom_in { }',
+        { }
+    );
+});
+
+it('remove :global - as part of @keyframe params with a dash', () => {
+    return run(
+        '@keyframes :global(zoom-in) { }',
+        '@keyframes zoom-in { }',
+        { }
+    );
 });

--- a/index.test.js
+++ b/index.test.js
@@ -35,6 +35,14 @@ it('remove :global - as part of selector with multiple spaces', () => {
         { });
 });
 
+// eslint-disable-next-line max-len
+it('remove multiple :global - as part of selector with selector included', () => {
+    return run(
+        '.root :global(.foo) :global(.bar) .text { margin: 0 6px; }',
+        '.root .foo .bar .text { margin: 0 6px; }',
+        { });
+});
+
 it('remove :global - as part of @keyframe params', () => {
     return run('@keyframes :global(zoomIn) { }', '@keyframes zoomIn { }', { });
 });


### PR DESCRIPTION
This PR fixes:

1) removing multiple `:global` selectors in a single rule
1) removing `:global` as part of selector with selector with dashes included
1) removing `:global` as part of @keyframe params with dashes included

I also added a tests for all fixed issues.